### PR TITLE
fix LFLabel iOS10 textlayout get wrong width bug

### DIFF
--- a/LFYYKit/Text/String/NSAttributedString+LFText.m
+++ b/LFYYKit/Text/String/NSAttributedString+LFText.m
@@ -47,13 +47,14 @@
 }
 
 - (NSDictionary *)attributesAtIndex:(NSUInteger)index {
+    if (index > self.length || self.length == 0) return nil;
     if (self.length > 0 && index == self.length) index--;
     return [self attributesAtIndex:index effectiveRange:NULL];
 }
 
 - (id)attribute:(NSString *)attributeName atIndex:(NSUInteger)index {
     if (!attributeName) return nil;
-    if (self.length == 0) return nil;
+    if (index > self.length || self.length == 0) return nil;
     if (self.length > 0 && index == self.length) index--;
     return [self attribute:attributeName atIndex:index effectiveRange:NULL];
 }


### PR DESCRIPTION
LFLabel in iOS10 have a bug, textLayout get a wrong width. fix it. 